### PR TITLE
rename format() to prevent collision with the Ruby kernel method

### DIFF
--- a/lib/classnames.rb
+++ b/lib/classnames.rb
@@ -3,7 +3,7 @@ module ClassNames
     args = Array(args)
 
     args.reduce([]) do |arr, arg|
-      if value = format(arg)
+      if value = format_classnames(arg)
         arr << value
       else
         arr
@@ -13,9 +13,9 @@ module ClassNames
 
   private
 
-  def format arg
+  def format_classnames arg
     if arg.is_a?(Hash)
-      format_hash(arg)
+      format_classnames_hash(arg)
     elsif arg.respond_to?(:call)
       arg.call
     else
@@ -23,7 +23,7 @@ module ClassNames
     end
   end
 
-  def format_hash hsh
+  def format_classnames_hash hsh
     hsh.reduce([]) do |result, kv|
       key, value = kv
 


### PR DESCRIPTION
The format() method was conflicting with Ruby kernel method by the same name.  If this is acceptable, should I bump the version number as well?

Thanks!
Joe
